### PR TITLE
Avoid exceptions when positions length is 0 or when changing position…

### DIFF
--- a/Runtime/TubeRenderer.cs
+++ b/Runtime/TubeRenderer.cs
@@ -59,6 +59,8 @@ namespace Unity.TubeRenderer
 
         private Mesh CreateMesh()
         {
+            if (positions != null && positions.Length == 0) return null;
+
             Vector3[] interpolatedPositions = Enumerable.Range(0, (positions.Length - 1) * subdivisions)
                 .Select(i => ((float)i) / ((float)subdivisions))
                 .Select(f => GetPosition(f))
@@ -113,6 +115,7 @@ namespace Unity.TubeRenderer
                     }
                 }
             }
+            mesh.Clear();
             mesh.vertices = verts;
             mesh.uv = uvs;
             mesh.normals = normals;


### PR DESCRIPTION
Hi, In my code I'm changing the positions length dynamically, which caused 2 issues:
1. Setting to zero length, the code would still try to create and use positions.length-1. To resolve this one, I checked the size at the head of the CreateMesh function
2. Changing the positions to a smalller number, I got the following error:
Mesh.vertices is too small. The supplied vertex array has less vertices than are referenced by the triangles array. UnityEngine.Mesh:set_vertices(Vector3[])
Following this thread- http://answers.unity.com/answers/1137125/view.html, I added mesh.Clear() before setting the mesh vertices 
